### PR TITLE
test: move tests that use HTTP calls into an 'http' test suite

### DIFF
--- a/src/price/coinpaprika.price.platform.tests.cpp
+++ b/src/price/coinpaprika.price.platform.tests.cpp
@@ -20,36 +20,39 @@
 
 namespace antara::mmbot::tests
 {
-    TEST_CASE ("simple get price coinpaprika working")
+    TEST_SUITE ("http")
     {
-        auto cfg = load_mmbot_config(std::filesystem::current_path() / "assets", "mmbot_config.json");
-        std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
-        antara::pair currency_pair{{antara::st_symbol{"EUR"}}, {antara::st_symbol{"KMD"}}};
-        CHECK_GT(price_platform->get_price(currency_pair, 0u).value(), 0);
-    }
+        TEST_CASE ("simple get price coinpaprika working")
+        {
+            auto cfg = load_mmbot_config(std::filesystem::current_path() / "assets", "mmbot_config.json");
+            std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
+            antara::pair currency_pair{{antara::st_symbol{"EUR"}}, {antara::st_symbol{"KMD"}}};
+            CHECK_GT(price_platform->get_price(currency_pair, 0u).value(), 0);
+        }
 
-    TEST_CASE ("simple get price coinpaprika working with unknown pair")
-    {
-        auto cfg = load_mmbot_config(std::filesystem::current_path() / "assets", "mmbot_config.json");
-        std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
-        antara::pair currency_pair{{st_symbol{"DOGE"}}, {st_symbol{"KMD"}}};
-        auto res = price_platform->get_price(currency_pair, 0u).value();
-        CHECK_GT(res, 0);
-    }
+        TEST_CASE ("simple get price coinpaprika working with unknown pair")
+        {
+            auto cfg = load_mmbot_config(std::filesystem::current_path() / "assets", "mmbot_config.json");
+            std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
+            antara::pair currency_pair{{st_symbol{"DOGE"}}, {st_symbol{"KMD"}}};
+            auto res = price_platform->get_price(currency_pair, 0u).value();
+            CHECK_GT(res, 0);
+        }
 
-    TEST_CASE ("simple get price coinpaprika wrong base")
-    {
-        auto cfg = load_configuration<config>(std::filesystem::current_path() / "assets", "mmbot_config.json");
-        std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
-        antara::pair currency_pair{{st_symbol{"EUR"}}, {st_symbol{"NONEXISTENTBASE"}}};
-        CHECK_EQ(price_platform->get_price(currency_pair, 0u).value(), 0);
-    }
+        TEST_CASE ("simple get price coinpaprika wrong base")
+        {
+            auto cfg = load_configuration<config>(std::filesystem::current_path() / "assets", "mmbot_config.json");
+            std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
+            antara::pair currency_pair{{st_symbol{"EUR"}}, {st_symbol{"NONEXISTENTBASE"}}};
+            CHECK_EQ(price_platform->get_price(currency_pair, 0u).value(), 0);
+        }
 
-    TEST_CASE ("simple get price coinpaprika wrong quote")
-    {
-        auto cfg = load_configuration<config>(std::filesystem::current_path() / "assets", "mmbot_config.json");
-        std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
-        antara::pair currency_pair{{st_symbol{"NONEXISTENTQUOTE"}}, {st_symbol{"KMD"}}};
-        CHECK_EQ(price_platform->get_price(currency_pair, 0u).value(), 0);
+        TEST_CASE ("simple get price coinpaprika wrong quote")
+        {
+            auto cfg = load_configuration<config>(std::filesystem::current_path() / "assets", "mmbot_config.json");
+            std::unique_ptr<abstract_price_platform> price_platform = std::make_unique<coinpaprika_price_platform>(cfg);
+            antara::pair currency_pair{{st_symbol{"NONEXISTENTQUOTE"}}, {st_symbol{"KMD"}}};
+            CHECK_EQ(price_platform->get_price(currency_pair, 0u).value(), 0);
+        }
     }
 }

--- a/src/price/service.price.platform.tests.cpp
+++ b/src/price/service.price.platform.tests.cpp
@@ -21,70 +21,73 @@
 namespace antara::mmbot::tests
 {
     //! BDD
-    SCENARIO("price service functionnality") {
-        GIVEN("a price service with a good configuration") {
-            auto cfg = load_mmbot_config(std::filesystem::current_path() / "assets", "mmbot_config.json");
-            price_service_platform price_service{cfg};
-            WHEN("give a valid asset pair") {
-                antara::pair currency_pair{{st_symbol{"EUR"}},
-                                           {st_symbol{"KMD"}}};
-                THEN("i ask for the price of this valid pair") {
-                    auto price = price_service.get_price(currency_pair).value();
-                    AND_THEN("i'm exepecting to get a price greater than zero") {
-                        CHECK_GT(price, 0);
+    TEST_SUITE ("http")
+    {
+        SCENARIO("price service functionnality") {
+            GIVEN("a price service with a good configuration") {
+                auto cfg = load_mmbot_config(std::filesystem::current_path() / "assets", "mmbot_config.json");
+                price_service_platform price_service{cfg};
+                WHEN("give a valid asset pair") {
+                    antara::pair currency_pair{{st_symbol{"EUR"}},
+                                              {st_symbol{"KMD"}}};
+                    THEN("i ask for the price of this valid pair") {
+                        auto price = price_service.get_price(currency_pair).value();
+                        AND_THEN("i'm exepecting to get a price greater than zero") {
+                            CHECK_GT(price, 0);
+                        }
                     }
                 }
-            }
-            AND_WHEN("give a wrong asset pair") {
-                antara::pair currency_pair{{st_symbol{"EUR"}},
-                                           {st_symbol{"NONEXISTENT"}}};
-                THEN("i ask for the price of this wrong pair") {
-                    AND_THEN("i'm exepecting to get an exception pair not available") {
-                        CHECK_THROWS_AS(price_service.get_price(currency_pair), errors::pair_not_available);
+                AND_WHEN("give a wrong asset pair") {
+                    antara::pair currency_pair{{st_symbol{"EUR"}},
+                                              {st_symbol{"NONEXISTENT"}}};
+                    THEN("i ask for the price of this wrong pair") {
+                        AND_THEN("i'm exepecting to get an exception pair not available") {
+                            CHECK_THROWS_AS(price_service.get_price(currency_pair), errors::pair_not_available);
+                        }
                     }
                 }
-            }
-            AND_WHEN("i want to get price with a registry of symbols") {
-                THEN("i create the registry of symbols that i to get price") {
-                    registry_quotes_for_specific_base registry_symbols{{"KMD", {st_symbol{"DOGE"}, st_symbol{"ETH"}, st_symbol{"BTC"}}}, {"ZIL", {st_symbol{"KMD"}}}};
-                    AND_THEN("i ask for the price using the registry of symbols") {
-                        auto res = price_service.get_price(registry_symbols);
-                        AND_THEN("i should atleast get 4 different price that's all greater than 0")
-                        {
-                            CHECK(!res.empty());
-                            CHECK_EQ_F(4u, res.size(), "size should be 4");
-                            for (auto&& current_result: res) {
-                                CHECK_GT(current_result.second.value(), 0);
+                AND_WHEN("i want to get price with a registry of symbols") {
+                    THEN("i create the registry of symbols that i to get price") {
+                        registry_quotes_for_specific_base registry_symbols{{"KMD", {st_symbol{"DOGE"}, st_symbol{"ETH"}, st_symbol{"BTC"}}}, {"ZIL", {st_symbol{"KMD"}}}};
+                        AND_THEN("i ask for the price using the registry of symbols") {
+                            auto res = price_service.get_price(registry_symbols);
+                            AND_THEN("i should atleast get 4 different price that's all greater than 0")
+                            {
+                                CHECK(!res.empty());
+                                CHECK_EQ_F(4u, res.size(), "size should be 4");
+                                for (auto&& current_result: res) {
+                                    CHECK_GT(current_result.second.value(), 0);
+                                }
+                                CHECK(!price_service.get_all_price().empty());
                             }
-                            CHECK(!price_service.get_all_price().empty());
                         }
                     }
                 }
             }
-        }
-        GIVEN("a price service with a wrong configuration (bad endpoint)") {
-            config cfg{};
-            cfg.price_registry["coinpaprika"] = price_config{st_endpoint{"wrong"}};
-            price_service_platform price_service{cfg};
-            WHEN("give a valid asset pair") {
-                antara::pair currency_pair{{st_symbol{"EUR"}},
-                                           {st_symbol{"KMD"}}};
-                THEN("i ask for the price of this valid pair") {
-                    AND_THEN("i'm exepecting to get an exception pair not available") {
-                        CHECK_THROWS_AS(price_service.get_price(currency_pair), errors::pair_not_available);
+            GIVEN("a price service with a wrong configuration (bad endpoint)") {
+                config cfg{};
+                cfg.price_registry["coinpaprika"] = price_config{st_endpoint{"wrong"}};
+                price_service_platform price_service{cfg};
+                WHEN("give a valid asset pair") {
+                    antara::pair currency_pair{{st_symbol{"EUR"}},
+                                              {st_symbol{"KMD"}}};
+                    THEN("i ask for the price of this valid pair") {
+                        AND_THEN("i'm exepecting to get an exception pair not available") {
+                            CHECK_THROWS_AS(price_service.get_price(currency_pair), errors::pair_not_available);
+                        }
                     }
                 }
             }
-        }
-        GIVEN("a price service with a wrong configuration (empty") {
-            config cfg{};
-            price_service_platform price_service{cfg};
-            WHEN("give a valid asset pair") {
-                antara::pair currency_pair{{st_symbol{"EUR"}},
-                                           {st_symbol{"KMD"}}};
-                THEN("i ask for the price of this valid pair") {
-                    AND_THEN("i'm exepecting to get an exception pair not available") {
-                        CHECK_THROWS_AS(price_service.get_price(currency_pair), errors::pair_not_available);
+            GIVEN("a price service with a wrong configuration (empty") {
+                config cfg{};
+                price_service_platform price_service{cfg};
+                WHEN("give a valid asset pair") {
+                    antara::pair currency_pair{{st_symbol{"EUR"}},
+                                              {st_symbol{"KMD"}}};
+                    THEN("i ask for the price of this valid pair") {
+                        AND_THEN("i'm exepecting to get an exception pair not available") {
+                            CHECK_THROWS_AS(price_service.get_price(currency_pair), errors::pair_not_available);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
The HTTP calls made by the tests mean that it sometimes takes 30 seconds to run. By putting these into an 'http' suite, they can be excluded using the `--test-suite-exclude=http` option with the test executable.