### PR TITLE
Add function for st_price * st_spread

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,8 @@ target_sources(mmbot_shared_deps INTERFACE
         price/coinpaprika.price.platform.cpp
         price/service.price.platform.cpp
         strategy_manager/strategy.manager.cpp
-        utils/antara.utils.cpp)
+        utils/antara.utils.cpp
+        utils/mmbot_strong_types.cpp)
 target_compile_features(mmbot_shared_deps INTERFACE cxx_std_17)
 target_include_directories(mmbot_shared_deps INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(mmbot_shared_deps INTERFACE absl::numeric mmbot::bcmath mmbot::log mmbot::http mmbot::default_settings nlohmann_json::nlohmann_json strong_type Cpp-Taskflow mmbot::restinio
@@ -34,7 +35,8 @@ target_sources(mmbot-test PUBLIC
         price/factory.price.plaftorm.tests.cpp
         price/service.price.platform.tests.cpp
         http/http.server.tests.cpp
-        utils/antara.utils.tests.cpp)
+        utils/antara.utils.tests.cpp
+        utils/mmbot_strong_types.tests.cpp)
 target_link_libraries(mmbot-test PRIVATE doctest trompeloeil PUBLIC mmbot_shared_deps)
 target_enable_coverage(mmbot-test)
 target_enable_tsan(mmbot-test)

--- a/src/strategy_manager/strategy.manager.cpp
+++ b/src/strategy_manager/strategy.manager.cpp
@@ -54,7 +54,7 @@ namespace antara::mmbot
     strategy_manager::make_bid(antara::st_price mid, antara::st_spread spread, antara::st_quantity quantity)
     {
         antara::st_spread mod = antara::st_spread{1.0} - spread;
-        antara::st_price price = mid; //* mod;
+        antara::st_price price = mid * mod;
         antara::side side = antara::side::buy;
         orders::order_level ol{antara::st_price{price}, quantity, side};
         return ol;
@@ -64,7 +64,7 @@ namespace antara::mmbot
     strategy_manager::make_ask(antara::st_price mid, antara::st_spread spread, antara::st_quantity quantity)
     {
         antara::st_spread mod = 1.0 + spread;
-        antara::st_price price = mid; //* mod;
+        antara::st_price price = mid * mod;
         antara::side side = antara::side::sell;
         orders::order_level ol{price, quantity, side};
         return ol;

--- a/src/strategy_manager/strategy.manager.tests.cpp
+++ b/src/strategy_manager/strategy.manager.tests.cpp
@@ -65,7 +65,7 @@ namespace antara::mmbot::tests
         auto expected = orders::order_level{bid_price, quantity, antara::side::buy};
         auto actual = strategy_manager::make_bid(mid, spread, quantity);
 
-        //CHECK_EQ(expected, actual);
+        CHECK_EQ(expected, actual);
     }
 
     TEST_CASE ("asks can be made")
@@ -81,7 +81,7 @@ namespace antara::mmbot::tests
         auto expected = orders::order_level{ask_price, quantity, antara::side::sell};
         auto actual = strategy_manager::make_ask(mid, spread, quantity);
 
-        //CHECK_EQ(expected, actual);
+        CHECK_EQ(expected, actual);
     }
 
 }

--- a/src/utils/mmbot_strong_types.cpp
+++ b/src/utils/mmbot_strong_types.cpp
@@ -26,4 +26,14 @@ namespace antara
         const int dp = 1000;
         return st_price{(price.value() * absl::uint128(spread.value() * dp)) / dp};
     }
+
+    bool operator==(const st_price &price, const st_price &other)
+    {
+        return price.value() == other.value();
+    }
+
+    bool operator<(const st_price &price, const st_price &other)
+    {
+        return price.value() < other.value();
+    }
 }

--- a/src/utils/mmbot_strong_types.cpp
+++ b/src/utils/mmbot_strong_types.cpp
@@ -19,9 +19,11 @@
 
 namespace antara
 {
-    st_price operator*(st_price price, st_spread spread)
+    st_price operator*(const st_price &price, const st_spread &spread)
     {
-        return st_price{(price.value() * absl::uint128(spread.value() * 1000)) / 1000};
-        // return st_price{0};
+        // This means that spreads are accurate to 0.001 or 0.1%
+        // Necessary for the conversion from double to uint128
+        const int dp = 1000;
+        return st_price{(price.value() * absl::uint128(spread.value() * dp)) / dp};
     }
 }

--- a/src/utils/mmbot_strong_types.cpp
+++ b/src/utils/mmbot_strong_types.cpp
@@ -1,0 +1,27 @@
+/******************************************************************************
+ * Copyright © 2013-2019 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#include "mmbot_strong_types.hpp"
+#include <absl/numeric/int128.h>
+
+namespace antara
+{
+    st_price operator*(st_price price, st_spread spread)
+    {
+        return st_price{(price.value() * absl::uint128(spread.value() * 1000)) / 1000};
+        // return st_price{0};
+    }
+}

--- a/src/utils/mmbot_strong_types.hpp
+++ b/src/utils/mmbot_strong_types.hpp
@@ -53,11 +53,13 @@ namespace antara
 
     using st_price = st::type<
             absl::uint128,
-            struct price_tag,
-            st::arithmetic
+            struct price_tag //,
+            // st::arithmetic
     >;
 
     st_price operator*(const st_price &price, const st_spread &spread);
+    bool operator==(const st_price &price, const st_price &other);
+    bool operator<(const st_price &price, const st_price &other);
 
     using st_order_id = std::string;
 

--- a/src/utils/mmbot_strong_types.hpp
+++ b/src/utils/mmbot_strong_types.hpp
@@ -57,6 +57,8 @@ namespace antara
             st::arithmetic
     >;
 
+    st_price operator*(st_price price, st_spread spread);
+
     using st_order_id = std::string;
 
     using st_execution_id = std::string;

--- a/src/utils/mmbot_strong_types.hpp
+++ b/src/utils/mmbot_strong_types.hpp
@@ -57,7 +57,7 @@ namespace antara
             st::arithmetic
     >;
 
-    st_price operator*(st_price price, st_spread spread);
+    st_price operator*(const st_price &price, const st_spread &spread);
 
     using st_order_id = std::string;
 

--- a/src/utils/mmbot_strong_types.tests.cpp
+++ b/src/utils/mmbot_strong_types.tests.cpp
@@ -20,13 +20,13 @@
 
 namespace antara::mmbot::tests
 {
-    TEST_CASE ("st_price can * with st_spread")
+    TEST_CASE ("st_price can multiply with st_spread")
     {
         auto price = st_price{100};
         auto spread = st_spread{1.05};
 
         auto expected = st_price{105};
 
-        CHECK_EQ(expected, price * spread);
+        CHECK_EQ(expected.value(), (price * spread).value());
     }
 }

--- a/src/utils/mmbot_strong_types.tests.cpp
+++ b/src/utils/mmbot_strong_types.tests.cpp
@@ -1,0 +1,32 @@
+/******************************************************************************
+ * Copyright © 2013-2019 The Komodo Platform Developers.                      *
+ *                                                                            *
+ * See the AUTHORS, DEVELOPER-AGREEMENT and LICENSE files at                  *
+ * the top-level directory of this distribution for the individual copyright  *
+ * holder information and the developer policies on copyright and licensing.  *
+ *                                                                            *
+ * Unless otherwise agreed in a custom licensing agreement, no part of the    *
+ * Komodo Platform software, including this file may be copied, modified,     *
+ * propagated or distributed except according to the terms contained in the   *
+ * LICENSE file                                                               *
+ *                                                                            *
+ * Removal or modification of this copyright notice is prohibited.            *
+ *                                                                            *
+ ******************************************************************************/
+
+#include <doctest/doctest.h>
+
+#include <utils/mmbot_strong_types.hpp>
+
+namespace antara::mmbot::tests
+{
+    TEST_CASE ("st_price can * with st_spread")
+    {
+        auto price = st_price{100};
+        auto spread = st_spread{1.05};
+
+        auto expected = st_price{105};
+
+        CHECK_EQ(expected, price * spread);
+    }
+}


### PR DESCRIPTION
Allows prices and spreads to be multiplied, fixing the function of the strategy manager.